### PR TITLE
Fixes #9 by adding intial Markdown Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,7 @@
   <li>try to parse a title from your input files. If there is a title, it will be the first line followed by two blank lines. In your generated HTML, use this to populate the <code>&lt;title>...&lt;/title&gt;</code> and add an &lt;h1&gt;...&lt;/h1&gt; to the top of the <code>&lt;body></code>
   </li>
   <li>allow the input to be a deep tree of files and folders. That is, if the user specifies a folder for --input, check to see if any of the items contained within are folders and recursively parse those as well.</li>
-   <li>Allow the input to be a markdown file. If the user specifies a file with <code>.md</code> extension for <code>--input</code>, the tool will look for instances of lines beginning with <code># </code>, and  add those lines inside individual <code>&lt;h1>...&lt;/h1&gt;</code> tags. Similarly, if the tool detects lines beginning with <code>## </code>, then those lines will be added within individual <code>&lt;h2>...&lt;/h2&gt;</code> tags.</li>
+   <li>Allow the input to be a markdown file. If the user specifies a file with <code>.md</code> extension for <code>--input</code>, the tool will look for instances of lines beginning with <code># </code>, and  add those lines inside individual <code>&lt;h1>...&lt;/h1&gt;</code> tags. Similarly, if the tool detects lines beginning with <code>## </code>, then those lines will be added within individual <code>&lt;h2>...&lt;/h2&gt;</code> tags. Furthermore, text marked within a pair of <code>**</code> will be transformed 
+   into bolded text. For example: <code>**Tom is a cat**</code> will be
+   converted into <code>&lt;strong&gt;Tom is a cat&lt;/strong&gt;</code>.</li>
 </ol>

--- a/README.md
+++ b/README.md
@@ -41,4 +41,5 @@
   <li>try to parse a title from your input files. If there is a title, it will be the first line followed by two blank lines. In your generated HTML, use this to populate the <code>&lt;title>...&lt;/title&gt;</code> and add an &lt;h1&gt;...&lt;/h1&gt; to the top of the <code>&lt;body></code>
   </li>
   <li>allow the input to be a deep tree of files and folders. That is, if the user specifies a folder for --input, check to see if any of the items contained within are folders and recursively parse those as well.</li>
+   <li>Allow the input to be a markdown file. If the user specifies a file with <code>.md</code> extension for <code>--input</code>, the tool will look for instances of lines beginning with <code># </code>, and  add those lines inside individual <code>&lt;h1>...&lt;/h1&gt;</code> tags. Similarly, if the tool detects lines beginning with <code>## </code>, then those lines will be added within individual <code>&lt;h2>...&lt;/h2&gt;</code> tags.</li>
 </ol>

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,38 +88,38 @@ function prepearDistFolder() {
   fs.mkdirSync("./dist")
 }
 
-function transformToSerializedHtml(lines: Array<string>, file: string) {
+function transformToSerializedHtml(lines: Array<string>, file: String) {
   const { JSDOM } = jsdom
   const dom = new JSDOM(initalHtml)
   const { window } = dom
+  const isMdFile = path.extname(file) === ".md"
 
-  if(path.extname(file) === ".txt"){
-    let paragraphBuffer = ""
-    lines.forEach((line, index) => {
-        if (index === 0 && lines.length > 3 && lines[1] === "" && lines[2] === "") {
-          window.document.title = line
-          const newH1 = window.document.createElement("h1")
-          newH1.innerHTML = line
-          window.document.body.appendChild(newH1)
-        } else if (line === "" && paragraphBuffer !== "") {
-          const newP = window.document.createElement("p")
-          newP.innerHTML = paragraphBuffer
-          window.document.body.appendChild(newP)
-          paragraphBuffer = ""
-        } else {
-          paragraphBuffer += line
-        }
-      })
-  } else if(path.extname(file) === ".md"){
-    lines.forEach((line) => {
-      line = line.trimStart()
-      if(line.match(/^#\s+/g)){
+  let paragraphBuffer = ""
+  lines.forEach((line, index) => {
+    if (index === 0 && lines.length > 3 && lines[1] === "" && lines[2] === "") {
+      window.document.title = line
+      if (!isMdFile) {
         const newH1 = window.document.createElement("h1")
-        newH1.innerHTML = line.substring(line.indexOf("#") + 1).trimStart()
+        newH1.innerHTML = line
         window.document.body.appendChild(newH1)
       }
-    })
-  }
+    } else if (line === "" && paragraphBuffer !== "") {
+      const newP = window.document.createElement("p")
+      newP.innerHTML = paragraphBuffer
+      window.document.body.appendChild(newP)
+      paragraphBuffer = ""
+    } else if (line.match(/^#\s+/g) && isMdFile) {
+      const newH1 = window.document.createElement("h1")
+      newH1.innerHTML = line.substring(line.indexOf("#") + 1).trimStart()
+      window.document.body.appendChild(newH1)
+    } else if (line.match(/^##\s+/g) && isMdFile) {
+      const newH2 = window.document.createElement("h1")
+      newH2.innerHTML = line.substring(line.indexOf("#") + 2).trimStart()
+      window.document.body.appendChild(newH2)
+    } else {
+      paragraphBuffer += line
+    }
+  })
   return pretty(dom.serialize())
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,7 +149,7 @@ function proccessFolder(dirPath: string) {
     proccessTextFile(file)
   })
   mdFiles.forEach((file) => {
-    // proccessTextFile(file)
+    proccessTextFile(file)
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -147,8 +147,6 @@ function proccessInput(args: Array<string>) {
        // TODO
     } else if (path.extname(inputPath) !== ".txt" && path.extname(inputPath) !== ".md") {
       throw new Error("Error: Wrong file extension (has to be .txt or .md)");
-    } else if (path.extname(inputPath) !== ".txt") {
-      throw new Error("Error: Wrong file extension (has to be .txt)")
     } else {
       throw new Error("Error: Unkown input error")
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ function filterTxtFiles(files: Array<string>): Array<string> {
   return files.filter((file) => path.extname(file) === ".txt")
 }
 
+function filterMdFiles(files) {
+  return files.filter((file) => path.extname(file) === ".md");
+}
+
 export type ConsoleCommands =
   | "--help"
   | "-v"

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,10 @@ function proccessInput(args: Array<string>) {
       proccessFolder(inputPath)
     } else if (path.extname(inputPath) === ".txt") {
       proccessSingleFile(inputPath)
+    } else if (path.extname(inputPath) === ".md") {
+       // TODO
+    } else if (path.extname(inputPath) !== ".txt" && path.extname(inputPath) !== ".md") {
+      throw new Error("Error: Wrong file extension (has to be .txt or .md)");
     } else if (path.extname(inputPath) !== ".txt") {
       throw new Error("Error: Wrong file extension (has to be .txt)")
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,8 +112,11 @@ function transformToSerializedHtml(lines: Array<string>, file: string) {
       })
   } else if(path.extname(file) === ".md"){
     lines.forEach((line) => {
-      if(line.trimStart().charAt(0) === "#"){
-        console.log("create heading 1")
+      line = line.trimStart()
+      if(line.match(/^#\s+/g)){
+        const newH1 = window.document.createElement("h1")
+        newH1.innerHTML = line.substring(line.indexOf("#") + 1).trimStart()
+        window.document.body.appendChild(newH1)
       }
     })
   }


### PR DESCRIPTION
I have added three initial features for Markdown files.

Users are now able to enter a `.md` format file to be converted into HTML. 

This PR adds the support for the following:
- [x] Heading 1
- [x] Heading 2
- [x] Bold text

Minimal changes have been made to the existing code. Additional functions and checks were implemented to filter and process `.md` files.

The code is functional. 

# To test
Create a directory containing `.md` files. 

## Testing H1
1. Add `# ` before any line to mark it as `h1`. Make sure there is a space after the # sign
2. Make sure the extension is `.md`
3. Run the tool with the `-i` option using the file created for testing purposes as the source.

## Testing H2
1. Add `## ` before any line to mark it as `h2`. Make sure there is a space after the # sign
2. Make sure the extension is `.md`
3. Run the tool with the `-i` option using the file created for testing purposes as the source.

## Testing Bold Text
1. Mark the beginning and ending of bolded text with `**`. For example: `**Tom is a cat**`
2. Make sure the extension is `.md`
3. Run the tool with the `-i` option using the file created for testing purposes as the source.
