### PR TITLE
Added config file functionality + couple tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
   <li><code>izyum -h | --help</code> - shows help message about ways to use the app</li>
   <li><code>izyum -i | --input [path to .txt file]</code> - transforms provided .txt file to html</li>
    <li><code>izyum -i | --input [path to dir]</code> - transforms all .txt files in that directory or in it's child directories to html</li>
+  <li><code>izyum -c | --config [path to .json file]</code> - performs commands specified in <code>json</code> format 
+  </li>
 </ul>
 
 <h2>Examles</h2>
@@ -44,4 +46,5 @@
    <li>Allow the input to be a markdown file. If the user specifies a file with <code>.md</code> extension for <code>--input</code>, the tool will look for instances of lines beginning with <code># </code>, and  add those lines inside individual <code>&lt;h1>...&lt;/h1&gt;</code> tags. Similarly, if the tool detects lines beginning with <code>## </code>, then those lines will be added within individual <code>&lt;h2>...&lt;/h2&gt;</code> tags. Furthermore, text marked within a pair of <code>**</code> will be transformed 
    into bolded text, text marked with <code>`</code> will be transformed into html code text. For example: <code>**Tom is a cat**</code> will be
    converted into <code>&lt;strong&gt;Tom is a cat&lt;/strong&gt;</code>. Additionally, the line marked with 3 or more dash symbols (---) is converted to the <code>&lt;hr /></code></li></li>
+   <li>Allow for reading configuration file, performing speicified commands and arguments as keys and values, e.g calling <code>izyum --config config.json</code> with JSON entry as <code>"input": "tests"</code> will call <code>izyum --input tests</code>. </li>
 </ol>

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ export type ConsoleCommands =
   | "--help"
   | "-i"
   | "--input"
+  | "-c"
+  | "--config"
 
 const initalHtml = `<!doctype html>
 <html lang="en">
@@ -230,6 +232,26 @@ function proccessInput(args: Array<string>) {
   }
 }
 
+function processConfig(args: Array<string>) {
+  try {
+    validateInputArguments(args)
+    const inputPath = getInputFileName(args)
+    if (!fs.lstatSync(inputPath).isDirectory() && path.extname(inputPath) == '.json') {
+      const configObject = JSON.parse(fs.readFileSync(inputPath))
+      if (!('input' in configObject)) {
+        throw new Error('Error: No "input" property in config file')
+      }
+      proccessInput([configObject['input']])
+    } else if (path.extname(inputPath) !== ".json") {
+      throw new Error("Error: Wrong config file extension (has to be .json)")
+    } else {
+      throw new Error("Error: Unkown input error")
+    }
+  } catch (error) {
+    console.error(error.message)
+  }
+}
+
 function getArgs() {
   const args = process.argv.slice(2)
   return args
@@ -255,6 +277,10 @@ switch (symbols[0] as ConsoleCommands) {
   case "--input":
   case "-i":
     proccessInput(symbols.slice(1, symbols.length))
+    break
+  case "--config":
+  case "-c":
+    processConfig(symbols.slice(1, symbols.length))
     break
   default:
     console.error("unkown command, try --help")

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,5 @@
+{
+    "input": "tests",
+    "output": "build",
+    "lang": "uk-UA"
+}

--- a/tests/invalid-config.json
+++ b/tests/invalid-config.json
@@ -1,0 +1,3 @@
+{
+    "output": "docs"
+}


### PR DESCRIPTION
Resolves #15

I have added some functionality to support config files. Here are some details:

- If called `config` command, the specified config file will be read and parsed
- Every key/value represents command/argument
- If no input specified, the command aborts
- If the specified file is not JSON, the command aborts
- Config files are also parsing any future functionality that might be added, like `output` or `lang`, and ignoring them at current stage